### PR TITLE
Move Comment Body input to Environment Variable

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,6 +39,8 @@ runs:
   steps:
     - name: Gather Parameters
       id: get_parameters
+      env:
+        INPUTS_COMMENT_BODY: "${{ inputs.comment_body }}"
       run: |
         $statusCode = 0
         $message = ""
@@ -55,8 +57,8 @@ runs:
             throw "${{ inputs.comment_author }}/permission does not have sufficient permissions for ${{ inputs.github_repository }}"
           }
 
-          Write-Host "Parsing ${{ inputs.comment_body }}"
-          ($botName, $backport, $backportTargetBranch) = [System.Text.RegularExpressions.Regex]::Split("${{ inputs.comment_body }}", "\s+")
+          Write-Host "Parsing $INPUTS_COMMENT_BODY"
+          ($botName, $backport, $backportTargetBranch) = [System.Text.RegularExpressions.Regex]::Split("$($INPUTS_COMMENT_BODY)", "\s+")
 
           Write-Host "Grabbing PR details from ${{ inputs.pull_request_url }}"
           $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "${{ inputs.pull_request_url }}" | ConvertFrom-Json


### PR DESCRIPTION
Per (GitHub Documentation)[https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-an-intermediate-environment-variable), we're moving the template expansion of `inputs.comment_body` to an intermediate environment variable to prevent remote code injection during execution of the pwsh script.