### PR TITLE
Enable backports for the repo itself

### DIFF
--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -1,0 +1,40 @@
+# Backport trigger file adapated from https://github.com/xamarin/.github/blob/main/workflow-templates/backport-trigger/backport-trigger.yml
+# This trigger file is used as the basis for testing backports within the backport-bot-action repo itself
+name: Backport Trigger
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  setupBackport:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@gitbot backport')
+    outputs:
+      target_branch: ${{ steps.parse_comment.outputs.target_branch }}
+    steps:
+      - name: Parse Comment
+        id: parse_comment
+        run: |
+          Write-Host "Parsing $env:COMMENT"
+          ($botName, $backport, $backportTargetBranch) = [System.Text.RegularExpressions.Regex]::Split("$env:COMMENT", "\s+")
+          echo "::set-output name=target_branch::$backportTargetBranch"
+        shell: pwsh
+        env:
+          COMMENT: "${{ github.event.comment.body }}"
+
+  launchBackportBuild:
+    needs: setupBackport
+    uses: xamarin/backport-bot-action/.github/workflows/backport-action.yml@v1.0-test
+    with:
+      pull_request_url: ${{ github.event.issue.pull_request.url }}
+      target_branch: ${{ needs.setupBackport.outputs.target_branch }}
+      comment_author: ${{ github.actor }}
+      github_repository: ${{ github.repository }}
+      use_fork: false
+    secrets:
+      ado_organization: ${{ secrets.ADO_PROJECTCOLLECTION }}
+      ado_project: ${{ secrets.ADO_PROJECT }}
+      backport_pipeline_id: ${{ secrets.BACKPORT_PIPELINEID }}
+      ado_build_pat: ${{ secrets.ADO_BUILDPAT }}
+      github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}


### PR DESCRIPTION
To provide a means of testing backport update prior to releasing to production, enable backports in this `backport-bot-action` repo. We can then try out backports based on a topic branch in this repo prior to merging those changes to main