### PR TITLE
Launch the backport build targeting the main branch

### DIFF
--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -101,7 +101,7 @@ jobs:
                 resources = @{
                   repositories = @{
                     self = @{
-                      refName = "refs/heads/yaml-pipeline"
+                      refName = "refs/heads/main"
                     }
                   }
                 };

--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
               resources = @{
                 repositories = @{
                   self = @{
-                    refName = "refs/heads/dev/cadsit/backport-bot"
+                    refName = "refs/heads/main"
                   }
                 }
               };


### PR DESCRIPTION
Update branch refs to main since the needed `yaml-templates` pipeline changes have been merged to main with the following PR:
https://github.com/xamarin/yaml-templates/pull/226

The backport-action update from `yaml-templates` to `main` is interesting because it's set to `dev/cadsit/backport-bot` for the v1.1 label.  Since `yaml-templates` doesn't exist backports fail when attempting to launch the backport build against that branch

With this change (and when it's deployed to the v1.1 label) we'll be able to delete the `dev/cadsit/backport-bot` branch from the `yaml-templates` repo