### PR TITLE
Fix: Revert action.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -98,7 +98,7 @@ runs:
               resources = @{
                 repositories = @{
                   self = @{
-                    refName = "refs/heads/dev/cadsit/backport-bot"
+                    refName = "refs/heads/main"
                   }
                 }
               };

--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,6 @@
 name: Backport Pull Request from Comment
 description: Launches a Backport Job from a GitHub Comment on an Issue
+author: Connor Adsit <cadsit@microsoft.com>
 inputs:
   pull_request_url:
     description: URL of the pull request from the issue comment event
@@ -33,23 +34,8 @@ inputs:
     required: false
     default: 'false'
 
-# https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runs
 runs:
   using: "composite"
-  # https://docs.github.com/en/actions/creating-actions/metadata-syntax-for-github-actions#runsenv
-  env:
-    # Protect against script injection attacks via input variables (i.e., the content of the variables could be executed at the time of evaluation/expansion within a script)
-    # Scripts must consume the environment variable settings instead
-    GITHUB_REPOSITORY: "${{ inputs.github_repository }}"
-    GITHUB_ACCOUNT_PAT: "${{ inputs.github_account_pat }}"
-    COMMENT_AUTHOR: "${{ inputs.comment_author }}"
-    COMMENT_BODY: "${{ inputs.comment_body }}"
-    PULL_REQUEST_URL: "${{ inputs.pull_request_url }}"
-    USE_FORK: "${{ inputs.use_fork }}"
-    ADO_ORGANIZATION: "${{ inputs.ado_organization }}"
-    ADO_PROJECT: "${{ inputs.ado_project }}"
-    ADO_PIPELINE_ID: "${{ inputs.backport_pipeline_id }}"
-    ADO_BUILD_PAT: "${{ inputs.ado_build_pat }}"
   steps:
     - name: Gather Parameters
       id: get_parameters
@@ -57,39 +43,23 @@ runs:
         $statusCode = 0
         $message = ""
         try {
-          $gitHubRepository = $env:GITHUB_REPOSITORY
-          $gitHubAccountPAT = $env:GITHUB_ACCOUNT_PAT
-          $commentAuthor = $env:COMMENT_AUTHOR
-          $pullRequestUrl = $env:PULL_REQUEST_URL
-          $useFork = $env:USE_FORK
-
-          Write-Host "GITHUB_REPOSITORY: ${gitHubRepository}"
-          Write-Host "COMMENT_AUTHOR: ${commentAuthor}"
-          Write-Host "PULL_REQUEST_URL: ${pullRequestUrl}"
-          Write-Host "USE_FORK: ${useFork}"
-
-          ($repoOwner, $repoName) = $gitHubRepository.Split("/")
-          $headers = $headers = @{ Authorization = "token ${gitHubAccountPAT}"}
-          $uri = "https://api.github.com/repos/${repoOwner}/${repoName}/collaborators/${commentAuthor}/permission"
-          Write-Host "Checking ${repoOwner} membership for ${commentAuthor} via $uri"
+          ($repoOwner, $repoName) = "${{ inputs.github_repository }}".Split("/")
+          $headers = $headers = @{ Authorization = "token ${{ inputs.github_account_pat }}"}
+          $uri = "https://api.github.com/repos/$repoOwner/$repoName/collaborators/${{ inputs.comment_author }}/permission"
+          Write-Host "Checking $repoOwner membership for ${{ inputs.comment_author }} via $uri"
           $response = Invoke-WebRequest -Headers $headers -Uri $uri
           $content = $response.Content | ConvertFrom-Json
           $accessType = $content.permission
           Write-Host "Found membership: $accessType"
           if (-not ($accessType.Equals("admin") -or $accessType.Equals("write"))) {
-            throw "${commentAuthor}/permission does not have sufficient permissions for ${gitHubRepository}"
+            throw "${{ inputs.comment_author }}/permission does not have sufficient permissions for ${{ inputs.github_repository }}"
           }
 
-          $commentBody = $env:COMMENT_BODY
-          Write-Host "--------------------------------------------------------------------------------"
-          Write-Host "COMMENT_BODY"
-          Write-Host "--------------------------------------------------------------------------------"
-          Write-Host $commentBody
+          Write-Host "Parsing ${{ inputs.comment_body }}"
+          ($botName, $backport, $backportTargetBranch) = [System.Text.RegularExpressions.Regex]::Split("${{ inputs.comment_body }}", "\s+")
 
-          ($botName, $backport, $backportTargetBranch) = [System.Text.RegularExpressions.Regex]::Split($commentBody, "\s+")
-
-          Write-Host "Grabbing PR details from ${pullRequestUrl}"
-          $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "${pullRequestUrl}" | ConvertFrom-Json
+          Write-Host "Grabbing PR details from ${{ inputs.pull_request_url }}"
+          $response = Invoke-WebRequest -UseBasicParsing -Headers $headers -Uri "${{ inputs.pull_request_url }}" | ConvertFrom-Json
           $backportPRNumber = $response.number
 
           $parameters = @{
@@ -98,7 +68,7 @@ runs:
             BackportTargetBranch = "$backportTargetBranch";
             BackportPRNumber = "$backportPRNumber";
             BackportHeadSHA = "$($response.head.sha)";
-            UseFork = $useFork -eq "true";
+            UseFork = "${{ inputs.use_fork }}" -eq "true";
           } | ConvertTo-Json -Compress
 
           $json = $parameters.Replace("`"","'")
@@ -115,22 +85,10 @@ runs:
     - name: Launch ADO Build
       id: ado_build
       run: |
-        $adoOrganization = $env:ADO_ORGANIZATION
-        $adoProject = $env:ADO_PROJECT
-        $adoPipelineId = $env:ADO_PIPELINE_ID
-        $adoBuildPAT = $env:ADO_BUILD_PAT
-        $gitHubRepository = $env:GITHUB_REPOSITORY
-        $gitHubAccountPAT = $env:GITHUB_ACCOUNT_PAT
-
-        Write-Host "ADO_ORGANIZATION: ${adoOrganization}"
-        Write-Host "ADO_PROJECT: ${adoProject}"
-        Write-Host "ADO_PIPELINE_ID: ${adoPipelineId}"
-        Write-Host "GITHUB_REPOSITORY: ${gitHubRepository}"
-
         $message = ""
         $statusCode = 0
         try {
-          $launchURI = "https://dev.azure.com/${adoOrganization}/${adoProject}/_apis/pipelines/${adoPipelineId}/runs?api-version=6.0-preview.1"
+          $launchURI = "https://dev.azure.com/${{ inputs.ado_organization }}/${{ inputs.ado_project }}/_apis/pipelines/${{ inputs.backport_pipeline_id }}/runs?api-version=6.0-preview.1"
           Write-Host "Grabbing parameters from prior step"
           $parameters = ConvertFrom-Json "${{ steps.get_parameters.outputs.parameters }}"
           Write-Host "$parameters"
@@ -140,7 +98,7 @@ runs:
               resources = @{
                 repositories = @{
                   self = @{
-                    refName = "refs/heads/main"
+                    refName = "refs/heads/dev/cadsit/backport-bot"
                   }
                 }
               };
@@ -148,13 +106,13 @@ runs:
 
           Write-Host "Posting to $launchURI"
           Write-Host $jsonBody
-          $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":${adoBuildPAT}"))
+          $encoded = [Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes(":${{ inputs.ado_build_pat }}"))
           $headers = @{ Authorization = "Basic $encoded"}
 
           $response = Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -ContentType "application/json" -Uri $launchURI -Body $jsonBody
           $responseJson = ConvertFrom-Json $response.Content
           echo "Job successfully launched"
-          $message = "Backport Job to branch **$($parameters.BackportTargetBranch)** Created! The magic is happening [here](https://dev.azure.com/${adoOrganization}/${adoProject}/_build/results?buildId=$($responseJson.id))"
+          $message = "Backport Job to branch **$($parameters.BackportTargetBranch)** Created! The magic is happening [here](https://dev.azure.com/${{ inputs.ado_organization }}/${{ inputs.ado_project }}/_build/results?buildId=$($responseJson.id))"
         } catch {
           Write-Host $_.Exception.Message
           $message = "I couldn't create a backport to **$($parameters.BackportTargetBranch)** for you. :( Please check the Action logs for more details."
@@ -164,8 +122,8 @@ runs:
             body = $message
           } | ConvertTo-Json
 
-          $headers = @{ Authorization = "token ${gitHubAccountPAT}"}
-          $uri = "https://api.github.com/repos/${gitHubRepository}/issues/${{ steps.get_parameters.outputs.pr_number }}/comments"
+          $headers = @{ Authorization = "token ${{ inputs.github_account_pat }}"}
+          $uri = "https://api.github.com/repos/${{ inputs.github_repository }}/issues/${{ steps.get_parameters.outputs.pr_number }}/comments"
 
 
           Write-Host "Posting to $uri"


### PR DESCRIPTION
The updates to `action.yml` lead to the following build break and so reverting back to the original file

```
Current runner version: '2.304.0'
Operating System
Runner Image
Runner Image Provisioner
GITHUB_TOKEN Permissions
Secret source: Actions
Prepare workflow directory
Prepare all required actions
Getting action download info
Download action repository 'xamarin/backport-bot-action@v1.1' (SHA:374220ad84663c3916fb8c7b7c1d674118c09d4d)
Error: xamarin/backport-bot-action/v1.1/action.yml (Line: 53, Col: 3): Unexpected value 'steps'
Error: xamarin/backport-bot-action/v1.1/action.yml (Line: 53, Col: 3): Unexpected value 'steps'
Error: System.ArgumentNullException: Value cannot be null. (Parameter 'You are using a composite action but there are no steps provided in xamarin/backport-bot-action/v1.1/action.yml.')
   at GitHub.Runner.Worker.ActionManifestManager.ConvertRuns(IExecutionContext executionContext, TemplateContext templateContext, TemplateToken inputsToken, String fileRelativePath, MappingToken outputs)
   at GitHub.Runner.Worker.ActionManifestManager.Load(IExecutionContext executionContext, String manifestFile)
Error: Fail to load xamarin/backport-bot-action/v1.1/action.yml
```