### PR TITLE
GITHUB_TOKEN read-only change: Include permission block

### DIFF
--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -42,6 +42,13 @@ on:
 jobs:
   launch_ado_build:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
     env:
       # Protect against script injection attacks via input variables (i.e., the content of the variables could be executed at the time of evaluation/expansion within a script)
       # Scripts must consume the environment variable settings instead

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -1,4 +1,4 @@
-# Backport trigger file adapated from https://github.com/xamarin/.github/blob/main/workflow-templates/backport-trigger/backport-trigger.yml
+# Backport trigger file adapted from https://github.com/xamarin/.github/blob/main/workflow-templates/backport-trigger/backport-trigger.yml
 # This trigger file is used as the basis for testing backports within the backport-bot-action repo itself
 name: Backport Trigger
 
@@ -9,6 +9,13 @@ on:
 jobs:
   setupBackport:
     runs-on: ubuntu-latest
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: write
+      contents: read
+      security-events: write
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@gitbot backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}

--- a/README.md
+++ b/README.md
@@ -64,3 +64,9 @@ You can list tags by executing the following command
 ```
 git tag
 ```
+
+To view the contents of a tag execute the following command:
+
+```
+git show $TAG_NAME
+```

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ git tag -f v1.0-test
 git push --tags --force
 ```
 
-To excercise your changes associated with the `v1.0-test` tag, use the following test PR
+To exercise your changes associated with the `v1.0-test` tag, use the following test PR
 https://github.com/xamarin/backport-bot-action/pull/11
 
 Apply the following comment to the PR
@@ -53,7 +53,7 @@ Please note that for updating the `v1.1` tag (or any other tag you want to push 
 
 In order to pick up the changes for Staging, make sure that the backport trigger YAML in your target repo (usually found at https://github.com/xamarin/$REPO_NAME/blob/main/.github/workflows/backport-trigger.yml) points to your desired tag.
 
-For example, https://github.com/xamarin/.github/blob/main/.github/workflows/backport-trigger.yml#L13, the uses line should be updated as follows:
+For example, https://github.com/xamarin/.github/blob/main/.github/workflows/backport-trigger.yml#L13, the `uses` line should be updated as follows:
 ```yaml
       - uses: xamarin/backport-bot-action@$TAG_NAME
 ```


### PR DESCRIPTION
Related work item: VS #[1943359](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1943359)

In anticipation of the GitHub change to make GITHUB_TOKEN read-only on 2024-02-01, add a permission block to the GitHub action yaml files per the following guidance:
https://docs.opensource.microsoft.com/github/apps/permission-changes/

Available permissions are documented here:
https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
