### PR TITLE
backport-trigger: Revise permissions based on sudden failures

### DIFF
--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -45,10 +45,11 @@ jobs:
     # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    # The workflow is not valid. .github/workflows/backport-trigger.yml (Line: 33, Col: 3): Error calling workflow 'xamarin/backport-bot-action/.github/workflows/backport-action.yml@v1.0-test'. The nested job 'launch_ado_build' is requesting 'actions: read, security-events: write', but is only allowed 'actions: none, security-events: none'.
     permissions:
-      actions: read
+      actions: none
       contents: read
-      security-events: write
+      security-events: none
     env:
       # Protect against script injection attacks via input variables (i.e., the content of the variables could be executed at the time of evaluation/expansion within a script)
       # Scripts must consume the environment variable settings instead

--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -45,7 +45,6 @@ jobs:
     # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
-    # The workflow is not valid. .github/workflows/backport-trigger.yml (Line: 33, Col: 3): Error calling workflow 'xamarin/backport-bot-action/.github/workflows/backport-action.yml@v1.0-test'. The nested job 'launch_ado_build' is requesting 'actions: read, security-events: write', but is only allowed 'actions: none, security-events: none'.
     permissions:
       actions: none
       contents: read

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -13,9 +13,9 @@ jobs:
     # https://docs.opensource.microsoft.com/github/apps/permission-changes/
     # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
     permissions:
-      actions: write
+      actions: none
       contents: read
-      security-events: write
+      security-events: none
     if: github.event.issue.pull_request != '' && startswith(github.event.comment.body, '@gitbot backport')
     outputs:
       target_branch: ${{ steps.parse_comment.outputs.target_branch }}


### PR DESCRIPTION
Backports suddenly started failing with the following error. I applied the same permissions as recommended by the error.

```
The workflow is not valid. .github/workflows/backport-trigger.yml (Line: 33, Col: 3): Error calling workflow 'xamarin/backport-bot-action/.github/workflows/backport-action.yml@v1.0-test'. The nested job 'launch_ado_build' is requesting 'actions: read, security-events: write', but is only allowed 'actions: none, security-events: none'.
```

This issue was first observed by the iOS but,  also impacted test backports per the PR here: https://github.com/xamarin/backport-bot-action/pull/11

More details regarding the failure can be found in the backport actions log here:
https://github.com/xamarin/backport-bot-action/actions/runs/7848577536