### PR TITLE
Fix for pipeline errors when calling Invoke-WebRequest

### DIFF
--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -144,7 +144,7 @@ jobs:
                 resources = @{
                   repositories = @{
                     self = @{
-                      refName = "refs/heads/dev/bond/backport-fix"   # UNDONE: TEST:
+                      refName = "refs/heads/main"
                     }
                   }
                 };

--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -144,7 +144,7 @@ jobs:
                 resources = @{
                   repositories = @{
                     self = @{
-                      refName = "refs/heads/main"
+                      refName = "refs/heads/dev/bond/backport-fix"   # UNDONE: TEST:
                     }
                   }
                 };

--- a/README.md
+++ b/README.md
@@ -12,8 +12,15 @@ trademarks or logos is subject to and must follow
 Use of Microsoft trademarks or logos in modified versions of this project must not cause confusion or imply Microsoft sponsorship.
 Any use of third-party trademarks or logos are subject to those third-party's policies.
 
-
 ## Testing
+
+To test `backport-bot.yml` pipeline changes, you will need to edit the `.github/workflows/backport-action.yml` file and temporarily update the trigger target branch from `main` to the name of your topic branch here:<br>
+https://github.com/xamarin/backport-bot-action/blob/b6cb9b0c1b51a5a03ba79cea51ee8602f24afe26/.github/workflows/backport-action.yml#L147
+
+For example change the `refName` setting from `refs/heads/main` to your topic branch such as `refs/heads/[TOPIC-BRANCH]`.  You should also add warning comment on the same line as a reminder to undo the change prior to merging your PR to main as follows:
+```
+refName = "refs/heads/[TOPIC-BRANCH]"  # UNDONE: DO NOT MERGE TO MAIN: Revert to using the main branch after testing
+```
 
 You can test changes from your topic branch (PR branch) by using the `v1.0-test` tag. Associate the tag with your latest changes by performing the following steps
 

--- a/backport-bot.yml
+++ b/backport-bot.yml
@@ -239,7 +239,7 @@ extends:
             $headers = @{ Authorization = "token $(github--pat--vs-mobiletools-engineering-service2)" }
 
             # let it throw
-            $response = Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri "https://api.github.com/repos/$(SourceRepo)/pulls" -Body ($payload | ConvertTo-json)
+            $response = Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri "https://api.github.com/repos/$(SourceRepo)/pulls" -Body ($payload | ConvertTo-json) -ContentType 'application/json'
             $newPr =  $response.Content | ConvertFrom-Json
 
             Write-Host "Response is $newPr"
@@ -257,7 +257,7 @@ extends:
               labels = $labels
             }
             Write-Host "https://api.github.com/repos/(SourceRepo)/issues/$($response.number)/labels"
-            $response = Invoke-WebRequest -UseBasicParsing -Method PUT -Headers $headers -Uri "https://api.github.com/repos/$(SourceRepo)/issues/$($newPr.number)/labels" -Body ($payload | ConvertTo-json)
+            $response = Invoke-WebRequest -UseBasicParsing -Method PUT -Headers $headers -Uri "https://api.github.com/repos/$(SourceRepo)/issues/$($newPr.number)/labels" -Body ($payload | ConvertTo-json) -ContentType 'application/json'
           displayName: Open Pull Request
           env:
             UseFork: ${{ parameters.UseFork }}
@@ -289,7 +289,7 @@ extends:
             Write-Host $statusJson
 
             $headers = @{ Authorization = "token $(github--pat--vs-mobiletools-engineering-service2)" }
-            Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri $uri -Body $statusJson
+            Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri $uri -Body $statusJson -ContentType 'application/json'
 
             # Comment on the original PR
             $commentJson = @{
@@ -298,6 +298,6 @@ extends:
 
             $commentApi = "https://api.github.com/repos/${{ parameters.BackportRepoOrg }}/${{ parameters.BackportRepoName }}/issues/${{ parameters.BackportPRNumber }}/comments"
             Write-Host "Commenting on original PR via $commentApi"
-            Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri $commentApi -Body $commentJson
+            Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri $commentApi -Body $commentJson -ContentType 'application/json'
           displayName: Report Status on PR
           condition: always()

--- a/backport-bot.yml
+++ b/backport-bot.yml
@@ -239,10 +239,12 @@ extends:
             $headers = @{ Authorization = "token $(github--pat--vs-mobiletools-engineering-service2)" }
 
             # let it throw
-            $response = Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri "https://api.github.com/repos/$(SourceRepo)/pulls" -Body ($payload | ConvertTo-json) -ContentType 'application/json'
+            $url = "https://api.github.com/repos/$(SourceRepo)/pulls"
+            Write-Host "Url pulls: ${url}"
+            $response = Invoke-WebRequest -UseBasicParsing -Method POST -Headers $headers -Uri $url -Body ($payload | ConvertTo-json) -ContentType 'application/json'
             $newPr =  $response.Content | ConvertFrom-Json
 
-            Write-Host "Response is $newPr"
+            Write-Host "Response: ${newPr}"
             # add labels to the new created PR
             [System.Collections.Generic.List[string]]$labels= @()
             $labels.Add("backported")
@@ -256,8 +258,10 @@ extends:
             $payload=@{
               labels = $labels
             }
-            Write-Host "https://api.github.com/repos/(SourceRepo)/issues/$($response.number)/labels"
-            $response = Invoke-WebRequest -UseBasicParsing -Method PUT -Headers $headers -Uri "https://api.github.com/repos/$(SourceRepo)/issues/$($newPr.number)/labels" -Body ($payload | ConvertTo-json) -ContentType 'application/json'
+
+            $url = "https://api.github.com/repos/$(SourceRepo)/issues/$($newPr.number)/labels"
+            Write-Host "Url labels: ${url}"
+            $response = Invoke-WebRequest -UseBasicParsing -Method PUT -Headers $headers -Uri $url -Body ($payload | ConvertTo-json) -ContentType 'application/json'
           displayName: Open Pull Request
           env:
             UseFork: ${{ parameters.UseFork }}


### PR DESCRIPTION
Azure DevOps web API calls are failing expecting a `Content-Type` header field.  Set the content type on all `Invoke-WebRequest` calls