### PR TITLE
Update trigger template with managed identity settings

### DIFF
--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -58,6 +58,7 @@ jobs:
       actions: none
       contents: read
       security-events: none
+      id-token: ${{ secrets.azure_client_id == '' && none || write }}   # https://docs.github.com/en/actions/learn-github-actions/expressions#operators
     env:
       # Protect against script injection attacks via input variables (i.e., the content of the variables could be executed at the time of evaluation/expansion within a script)
       # Scripts must consume the environment variable settings instead

--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -58,7 +58,7 @@ jobs:
       actions: none
       contents: read
       security-events: none
-      id-token: ${{ secrets.azure_client_id == '' && none || write }}   # https://docs.github.com/en/actions/learn-github-actions/expressions#operators
+      id-token: none
     env:
       # Protect against script injection attacks via input variables (i.e., the content of the variables could be executed at the time of evaluation/expansion within a script)
       # Scripts must consume the environment variable settings instead

--- a/.github/workflows/backport-action.yml
+++ b/.github/workflows/backport-action.yml
@@ -24,6 +24,15 @@ on:
         required: false
         default: false
     secrets:
+      azure_tenant_id:
+        description: Tenant associated with the managed identity used to log into Azure
+        required: false
+      azure_subscription_id:
+        description: Subscription associated with the managed identity used to log into Azure
+        required: false
+      azure_client_id:
+        description: Client id associated with the managed identity used to log into Azure
+        required: false
       ado_organization:
         description: Azure DevOps organization that hosts the backport job
         required: true
@@ -33,12 +42,12 @@ on:
       backport_pipeline_id:
         description: ID of the backport yaml pipeline in Azure DevOps
         required: true
-      ado_build_pat:
-        description: PAT of an account that can launch builds on the backport pipeline in Azure DevOps
-        required: true
       github_account_pat:
         description: PAT for a github account that has write access to source repository
         required: true
+      ado_build_pat:
+        description: PAT of an account that can launch builds on the backport pipeline in Azure DevOps
+        required: false
 jobs:
   launch_ado_build:
     runs-on: ubuntu-latest

--- a/.github/workflows/backport-trigger.yml
+++ b/.github/workflows/backport-trigger.yml
@@ -33,6 +33,14 @@ jobs:
   launchBackportBuild:
     needs: setupBackport
     uses: xamarin/backport-bot-action/.github/workflows/backport-action.yml@v1.0-test
+    # GITHUB_TOKEN change from read-write to read-only on 2024-02-01 requiring permissions block
+    # https://docs.opensource.microsoft.com/github/apps/permission-changes/
+    # https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs
+    permissions:
+      actions: none
+      contents: read
+      security-events: none
+      id-token: write           # The backport-action template being invoked requires this permission
     with:
       pull_request_url: ${{ github.event.issue.pull_request.url }}
       target_branch: ${{ needs.setupBackport.outputs.target_branch }}
@@ -40,8 +48,11 @@ jobs:
       github_repository: ${{ github.repository }}
       use_fork: false
     secrets:
+      azure_tenant_id: ${{ secrets.AZURE_TENANT_ID }}
+      azure_subscription_id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      azure_client_id: ${{ secrets.AZURE_CLIENT_ID }}
       ado_organization: ${{ secrets.ADO_PROJECTCOLLECTION }}
       ado_project: ${{ secrets.ADO_PROJECT }}
       backport_pipeline_id: ${{ secrets.BACKPORT_PIPELINEID }}
-      ado_build_pat: ${{ secrets.ADO_BUILDPAT }}
       github_account_pat: ${{ secrets.SERVICEACCOUNT_PAT }}
+      ado_build_pat: ${{ secrets.ADO_BUILDPAT }}


### PR DESCRIPTION
Update trigger template with secret settings associated with a managed identity. The managed identity will be used in a subsequent change to authorize against Azure DevOps for launching a backport build

This PR is intentionally a partial solution to seed the backport-trigger with the managed identity related secrets that will be needed for Azure DevOps authorization.  To test changes that will be made in a subsequent PR to the backport-action template, we must first get the backport-trigger changes into main.  The reason for this is that actions are triggered based on the trigger yaml template in the default branch, which is `main` in this case. It might be possible to implement & test the complete managed identity authorization solution by changing the default branch to the topic branch, but I'm reluctant to make such as a change as it would likely lead to other unwanted side-effects